### PR TITLE
fix: POSIX line-continuation in process_command splitting

### DIFF
--- a/aliyun-net-credentials-unit-tests/Utils/CommandLineUtilsTest.cs
+++ b/aliyun-net-credentials-unit-tests/Utils/CommandLineUtilsTest.cs
@@ -121,6 +121,22 @@ namespace aliyun_net_credentials_unit_tests.Utils
         }
 
         [Fact]
+        public void TestBackslashNewlineOutsideQuotesIsLineContinuationUnix()
+        {
+            Assert.Equal(
+                new[] {"tool", "arg1", "arg2"},
+                CommandLineUtils.Split("tool arg1 \\\n arg2", false));
+        }
+
+        [Fact]
+        public void TestBackslashNewlineInsideDoubleQuotesIsLineContinuationUnix()
+        {
+            Assert.Equal(
+                new[] {"tool", "ab"},
+                CommandLineUtils.Split("tool \"a\\\nb\"", false));
+        }
+
+        [Fact]
         public void TestEmpty()
         {
             var ex = Assert.Throws<CredentialException>(() => CommandLineUtils.Split("   "));

--- a/aliyun-net-credentials/Utils/CommandLineUtils.cs
+++ b/aliyun-net-credentials/Utils/CommandLineUtils.cs
@@ -10,8 +10,9 @@ namespace Aliyun.Credentials.Utils
     /// so Windows paths like "C:\Program Files\tool.exe" work as one argument.
     ///
     /// On Unix, escape rules follow POSIX shlex: outside quotes, '\' escapes the
-    /// next char; inside double quotes, '\' only escapes '"', '\', '$', '`' and
-    /// newline; inside single quotes, all characters are literal.
+    /// next char; inside double quotes, '\' only escapes '"', '\', '$' and '`';
+    /// backslash-newline is a line continuation (both removed) outside single
+    /// quotes; inside single quotes, all characters are literal.
     ///
     /// On Windows, '\' is a path separator and is treated as a literal (except
     /// '\"' inside double quotes), so unquoted paths like C:\tools\cred.exe keep
@@ -77,7 +78,13 @@ namespace Aliyun.Credentials.Utils
                                 continue;
                             }
                         }
-                        else if (next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n')
+                        else if (next == '\n')
+                        {
+                            // Backslash-newline is a line continuation: both removed.
+                            i++;
+                            continue;
+                        }
+                        else if (next == '"' || next == '\\' || next == '$' || next == '`')
                         {
                             current.Append(next);
                             i++;
@@ -102,6 +109,13 @@ namespace Aliyun.Credentials.Utils
                     if (i + 1 >= input.Length)
                     {
                         throw new CredentialException("invalid process_command: trailing backslash");
+                    }
+
+                    if (input[i + 1] == '\n')
+                    {
+                        // Backslash-newline is a line continuation: both removed.
+                        i++;
+                        continue;
                     }
 
                     hasToken = true;


### PR DESCRIPTION
## Summary
- Treat backslash-newline as POSIX line continuation (both removed) in `CommandLineUtils.Split`, outside quotes and inside double quotes, matching shlex semantics (follow-up to #62).
- Add test cases for both continuation positions.